### PR TITLE
enforce atom ownership in SGroups

### DIFF
--- a/Code/GraphMol/Wrap/StereoGroup.cpp
+++ b/Code/GraphMol/Wrap/StereoGroup.cpp
@@ -22,38 +22,44 @@ namespace python = boost::python;
 using boost::python::converter::rvalue_from_python_stage1_data;
 
 namespace RDKit {
-
+namespace {
 std::string stereoGroupClassDoc =
     "A collection of atoms with a defined stereochemical relationship.\n\n"
     "Used to help represent a sample with unknown stereochemistry, or that "
     "is a mix\nof diastereomers.\n";
 
-static StereoGroup stereoGroupFactory(StereoGroupType grouptype, python::object atoms) {
-    std::vector<Atom*> cppAtoms;
-    pythonObjectToVect<Atom*>(atoms, cppAtoms);
-    return {grouptype, std::move(cppAtoms)};
+static StereoGroup stereoGroupFactory(StereoGroupType grouptype,
+                                      python::object atoms) {
+  std::vector<Atom*> cppAtoms;
+  pythonObjectToVect<Atom*>(atoms, cppAtoms);
+  return {grouptype, std::move(cppAtoms)};
 }
 
 // Is obj convertable to a vector?
-template <typename T> void* vector_convertable(PyObject* obj) {
+template <typename T>
+void* vector_convertable(PyObject* obj) {
   return PyList_Check(obj) ? obj : nullptr;
 }
 
 // Convert obj to a vector.
-template <typename T> void vector_convert(PyObject* obj, rvalue_from_python_stage1_data* data) {
-    // See
-    // https://www.boost.org/doc/libs/1_61_0/libs/python/doc/html/faq/how_can_i_automatically_convert_.html
+template <typename T>
+void vector_convert(PyObject* obj, rvalue_from_python_stage1_data* data) {
+  // See
+  // https://www.boost.org/doc/libs/1_61_0/libs/python/doc/html/faq/how_can_i_automatically_convert_.html
 
-    // Boost uses a borrowed reference here.
-    boost::python::object borrowed_obj(boost::python::handle<>(boost::python::borrowed(obj)));
-    python::stl_input_iterator<T> beg(borrowed_obj), end;
+  // Boost uses a borrowed reference here.
+  boost::python::object borrowed_obj(
+      boost::python::handle<>(boost::python::borrowed(obj)));
+  python::stl_input_iterator<T> beg(borrowed_obj), end;
 
-    // Allocate the C++ type into the converter's memory block
-    void* storage = ((boost::python::converter::rvalue_from_python_storage<std::vector<T>>*) data)->storage.bytes;
-    new (storage) std::vector<T>(beg, end);
-    data->convertible = storage;
+  // Allocate the C++ type into the converter's memory block
+  void* storage =
+      ((boost::python::converter::rvalue_from_python_storage<std::vector<T>>*)
+           data)
+          ->storage.bytes;
+  new (storage) std::vector<T>(beg, end);
+  data->convertible = storage;
 }
-
 
 // Wrap vector<T> for use in Python
 //
@@ -62,15 +68,32 @@ template <typename T> void vector_convert(PyObject* obj, rvalue_from_python_stag
 //
 // Python to C++: Either a wrapped C++ vector or a native Python list is
 // allowed.
-template <typename T> void register_vector2way(const char* name) {
+template <typename T>
+void register_vector2way(const char* name) {
   RegisterVectorConverter<T>(name);
 
   boost::python::converter::registry::push_back(
-      &vector_convertable<T>,
-      &vector_convert<T>,
+      &vector_convertable<T>, &vector_convert<T>,
       boost::python::type_id<std::vector<T>>());
 }
 
+StereoGroup* createAndReturnStereoGroup(ROMol* mol, python::object atomIds,
+                                        StereoGroupType typ) {
+  PRECONDITION(mol, "no molecule");
+  std::vector<Atom*> cppAtoms;
+  python::stl_input_iterator<unsigned int> beg(atomIds), end;
+  while (beg != end) {
+    unsigned int v = *beg;
+    if (v >= mol->getNumAtoms())
+      throw_value_error("atom index exceeds mol.GetNumAtoms()");
+    cppAtoms.push_back(mol->getAtomWithIdx(v));
+    ++beg;
+  }
+  StereoGroup* sg = new StereoGroup(typ, cppAtoms);
+  return sg;
+}
+
+}  // namespace
 struct stereogroup_wrap {
   static void wrap() {
     python::enum_<RDKit::StereoGroupType>("StereoGroupType")
@@ -81,17 +104,26 @@ struct stereogroup_wrap {
 
     register_vector2way<Atom*>("Atom_vect");
 
-    python::class_<StereoGroup, boost::shared_ptr<StereoGroup>> (
-        "StereoGroup", stereoGroupClassDoc.c_str(), python::init<>())
-        .def(python::init<RDKit::StereoGroupType, const ROMol::ATOM_PTR_VECT&>())
+    python::class_<StereoGroup, boost::shared_ptr<StereoGroup>>(
+        "StereoGroup", stereoGroupClassDoc.c_str(), python::no_init)
+        .def(
+            python::init<RDKit::StereoGroupType, const ROMol::ATOM_PTR_VECT&>())
         .def("GetGroupType", &StereoGroup::getGroupType,
              "Returns the StereoGroupType.\n")
         .def("GetAtoms", &StereoGroup::getAtoms,
              "Access the atoms in the StereoGroup.\n",
              python::return_internal_reference<
                  1, python::with_custodian_and_ward_postcall<0, 1>>());
+    python::def("CreateStereoGroup", &createAndReturnStereoGroup,
+                "creates a StereoGroup associated with a molecule from a list "
+                "of atom Ids",
+                (python::arg("mol"), python::arg("atomIds"),
+                 python::arg("stereoGroupType")),
+                python::return_value_policy<
+                    python::manage_new_object,
+                    python::with_custodian_and_ward_postcall<0, 1>>());
   }
 };
-}
+}  // namespace RDKit
 
 void wrap_stereogroup() { RDKit::stereogroup_wrap::wrap(); }


### PR DESCRIPTION
Some cleanups to make sure you can't add an S group with bogus atoms
to a molecule
